### PR TITLE
setup_tabular_sfh compiles and faster, fix bug for sfh=2,3 and tage=-99

### DIFF
--- a/src/compsp.f90
+++ b/src/compsp.f90
@@ -98,7 +98,7 @@ SUBROUTINE COMPSP(write_compsp, nzin, outfile,&
         age = pset%tage
      else if ((pset%tage.eq.-99).and.((pset%sfh.eq.2).or.(pset%sfh.eq.3))) then
         ! Special switch to just do the last time in the tabular file
-        age = maxval(sfh_tab(1, :))
+        age = maxval(sfh_tab(1, 1:ntabsfh)) / 1E9
      else
         ! Otherwise we will calculate composite spectra for every SSP age.
         age = 10**(time_full(i)-9.)
@@ -162,7 +162,7 @@ SUBROUTINE COMPSP(write_compsp, nzin, outfile,&
                       mass_csp, lbol_csp, tsfr, mags, spec_csp, mdust_csp, indx)
 
      ! Terminate the loop if a single specific tage was requested
-     if (pset%tage.gt.0) then
+     if ((pset%tage.gt.0).or.(pset%tage.eq.-99)) then
         exit
      endif
 

--- a/src/setup_tabular_sfh.f90
+++ b/src/setup_tabular_sfh.f90
@@ -68,10 +68,8 @@ subroutine setup_tabular_sfh(pset, nzin)
   ENDIF
 
   ! clip SFR to a minimum of 1e-30
-  if (minval(sfh_tab(2, 1:ntabsfh)).lt.tiny30) then
-     do i=1, ntabsfh
-        sfh_tab(2, i) = max(sfh_tab(2, i), tiny30)
-     enddo
-  endif        
+  do n=1, ntabsfh
+     sfh_tab(2, n) = max(sfh_tab(2, n), tiny30)
+  enddo
   
 end subroutine setup_tabular_sfh


### PR DESCRIPTION
The clipping of tabular sfrs is changed to be faster, and a bug is fixed so that it actually compiles.  Also fixes problems for tage=-99 and sfh=2,3.