### PR TITLE
Tabular Z, light weighting, mformed, and minor bug-fixes/speed improvements.

### DIFF
--- a/src/compsp.f90
+++ b/src/compsp.f90
@@ -221,7 +221,7 @@ SUBROUTINE COMPSP_WARNING(maxtime,pset,nzin,write_compsp)
      STOP
   ENDIF
 
-  IF (pset%sf_trunc.LT.pset%sf_start) THEN
+  IF ((pset%sf_trunc.LT.pset%sf_start).AND.(pset%sf_trunc.GT.tiny_number)) THEN
      WRITE(*,*) 'COMPSP WARNING: sf_trunc<sf_start....'//&
           ' sf_trunc will be ignored.'
   ENDIF

--- a/src/compsp.f90
+++ b/src/compsp.f90
@@ -289,10 +289,9 @@ SUBROUTINE COMPSP_WARNING(maxtime,pset,nzin,write_compsp)
      STOP
   ENDIF
 
-  IF ((pset%sfh.NE.1.AND.pset%sfh.NE.4).AND.&
-       compute_light_ages.EQ.1) THEN
-     WRITE(*,*) 'COMPSP ERROR: compute_light_ages only works with SFH=1 or 4'
-     STOP
+  if ((pset%dust1.gt.tiny_number).and.(compute_light_ages.eq.1)) then
+     WRITE(*,*) 'COMPSP WARNING: compute_light_ages does not take into'//&
+          ' account age-dependent dust (dust1 > 0)'
   ENDIF
      
 

--- a/src/compsp.f90
+++ b/src/compsp.f90
@@ -128,33 +128,33 @@ SUBROUTINE COMPSP(write_compsp, nzin, outfile,&
      ! Now do a bunch of stuff with the spectrum
      ! Smooth the spectrum
      if (pset%sigma_smooth.GT.0.0) then
-        call smoothspec(spec_lambda,spec_csp,pset%sigma_smooth,&
-                        pset%min_wave_smooth,pset%max_wave_smooth)
+        call smoothspec(spec_lambda, spec_csp, pset%sigma_smooth,&
+                        pset%min_wave_smooth, pset%max_wave_smooth)
      endif
      ! Add IGM absorption
      if (add_igm_absorption.EQ.1.AND.pset%zred.GT.tiny_number) then
-        spec_csp = igm_absorb(spec_lambda,spec_csp,pset%zred,&
+        spec_csp = igm_absorb(spec_lambda,spec_csp, pset%zred,&
                               pset%igm_factor)
      endif
      !add AGN dust
      IF (add_agn_dust.EQ.1.AND.pset%fagn.GT.tiny_number) THEN
-        spec_csp = agn_dust(spec_lambda,spec_csp,pset,lbol_csp)
+        spec_csp = agn_dust(spec_lambda, spec_csp, pset, lbol_csp)
      ENDIF
      ! Compute spectral indices
      if (write_compsp.EQ.4) then
-        call getindx(spec_lambda,spec_csp,indx)
+        call getindx(spec_lambda, spec_csp, indx)
      else
         indx = 0.0
      endif
      ! Compute mags
      if (redshift_colors.EQ.0) then
-        call getmags(pset%zred,spec_csp,mags,pset%mag_compute)
+        call getmags(pset%zred, spec_csp, mags, pset%mag_compute)
      else
         ! here we compute the redshift at the corresponding age
-        zred = min(max(linterp(cosmospl(:,2),cosmospl(:,1),&
-                       10**time_full(i)/1E9), 0.0), 20.0)
+        zred = min(max(linterp(cosmospl(:,2), cosmospl(:,1), age),&
+                       0.0), 20.0)
         write(33,*) zred
-        call getmags(zred,spec_csp,mags,pset%mag_compute)
+        call getmags(zred, spec_csp, mags, pset%mag_compute)
      endif
 
      ! ---------

--- a/src/compsp.f90
+++ b/src/compsp.f90
@@ -36,15 +36,15 @@ SUBROUTINE COMPSP(write_compsp, nzin, outfile,&
      STOP
   ENDIF
 
-  IF (nzin.GT.1) THEN
+  IF ((nzin.GT.1).and.(pset%sfh.ne.2).and.(pset%sfh.ne.3)) THEN
      WRITE(*,*) 'COMPSP ERROR: '//&
-          'nzin > 1 no longer supported. '
+          'nzin > 1 no longer supported for non-tabular SFH.'
      STOP
   ENDIF
 
   call setup_tabular_sfh(pset, nzin)
 
-  !make sure various variables are set correctly
+  ! Make sure various variables are set correctly
   IF (pset%tage.GT.tiny_number) THEN
      maxtime = pset%tage * 1e9
   else
@@ -53,7 +53,7 @@ SUBROUTINE COMPSP(write_compsp, nzin, outfile,&
   
   CALL COMPSP_WARNING(maxtime, pset, nzin, write_compsp)
 
-  !setup output files
+  ! Setup output files
   if (pset%tage.gt.0) then
      nage = 1
   else
@@ -109,7 +109,7 @@ SUBROUTINE COMPSP(write_compsp, nzin, outfile,&
      ! solar mass formed, so we actually need to renormalize if computing all
      ! ages, which is done using info from `sfhinfo`
      call csp_gen(mass_ssp, lbol_ssp, spec_ssp, &
-                  pset, age, &
+                  pset, age, nzin, &
                   mass_csp, lbol_csp, spec_csp, mdust_csp)
      
      call sfhinfo(pset, age, mass_frac, tsfr, frac_linear)

--- a/src/compsp.f90
+++ b/src/compsp.f90
@@ -160,7 +160,8 @@ SUBROUTINE COMPSP(write_compsp, nzin, outfile,&
      ! ---------
      ! Store the spectrum and write....
      call save_compsp(write_compsp, ocompsp(i), log10(age)+9,&
-                      mass_csp, lbol_csp, tsfr, mags, spec_csp, mdust_csp, indx)
+          mass_csp, lbol_csp, tsfr, mags, spec_csp, mdust_csp, mass_frac,&
+          indx)
 
      ! Terminate the loop if a single specific tage was requested
      if ((pset%tage.gt.0).or.(pset%tage.eq.-99)) then
@@ -458,14 +459,14 @@ END SUBROUTINE COMPSP_HEADER
 !------------------------------------------------------------!
 
 SUBROUTINE SAVE_COMPSP(write_compsp,cspo,time,mass,&
-     lbol,sfr,mags,spec,mdust,indx)
+     lbol,sfr,mags,spec,mdust,mformed,indx)
 
   !routine to print and save outputs
 
   USE sps_vars
   IMPLICIT NONE
   INTEGER, INTENT(in) :: write_compsp
-  REAL(SP), INTENT(in)    :: time,mass,lbol,sfr,mdust
+  REAL(SP), INTENT(in)    :: time,mass,lbol,sfr,mdust,mformed
   REAL(SP), DIMENSION(nspec), INTENT(in)  :: spec
   REAL(SP), DIMENSION(nbands), INTENT(in) :: mags
   REAL(SP), DIMENSION(nindx), INTENT(in)  :: indx
@@ -485,6 +486,7 @@ SUBROUTINE SAVE_COMPSP(write_compsp,cspo,time,mass,&
   cspo%mags     = mags
   cspo%spec     = MAX(spec,tiny_number)
   cspo%mdust    = mdust
+  cspo%mformed  = mformed
   cspo%indx     = indx
 
   !write to mags file

--- a/src/csp_gen.f90
+++ b/src/csp_gen.f90
@@ -207,7 +207,7 @@ subroutine csp_gen(mass_ssp, lbol_ssp, spec_ssp, &
      enddo
      ! Reset imin and imax for the spectral sum.
      imin = 0
-     imax = min(max(locate(time_full, log10(sfhpars%tage)) + 2, 1), ntfull)
+     imax = ntfull
   endif
 
   ! ----- Combine SSPs with dust -------

--- a/src/sfh_weight.f90
+++ b/src/sfh_weight.f90
@@ -48,6 +48,12 @@ function sfh_weight(sfh, imin, imax)
         return
      endif
      log_tb = log10(sfh%tb)
+     if (log_tb.le.time_full(1)) then
+        ! Just return all weight in the youngest ssp.
+        sfh_weight(1) = 1.0
+        return
+     endif
+
      istart = min(max(locate(time_full, log_tb), 1), ntfull-1)
      dt = delta_time(time_full(istart), time_full(istart+1))
      sfh_weight(istart) = delta_time(log_tb, time_full(istart+1)) / dt

--- a/src/sps_utils.f90
+++ b/src/sps_utils.f90
@@ -100,13 +100,14 @@ MODULE SPS_UTILS
   END INTERFACE
 
   INTERFACE
-     SUBROUTINE CSP_GEN(mass_ssp, lbol_ssp, spec_ssp, pset, tage,&
+     SUBROUTINE CSP_GEN(mass_ssp, lbol_ssp, spec_ssp, pset, tage, nzin,&
                         mass_csp, lbol_csp, spec_csp, mdust_csp)
        USE sps_vars
        REAL(SP), DIMENSION(ntfull), INTENT(in) :: mass_ssp, lbol_ssp
        REAL(SP), DIMENSION(nspec, ntfull), INTENT(in) :: spec_ssp
        TYPE(PARAMS), intent(in) :: pset
        REAL(SP), INTENT(in)  :: tage
+       INTEGER, INTENT(IN) :: nzin
        REAL(SP), INTENT(out) :: mass_csp, lbol_csp, mdust_csp
        REAL(SP), INTENT(out), DIMENSION(nspec) :: spec_csp
      END SUBROUTINE CSP_GEN

--- a/src/sps_vars.f90
+++ b/src/sps_vars.f90
@@ -458,7 +458,7 @@ MODULE SPS_VARS
   
   !structure for the output of the compsp routine
   TYPE COMPSPOUT
-     REAL(SP) :: age=0.,mass_csp=0.,lbol_csp=0.,sfr=0.,mdust=0.
+     REAL(SP) :: age=0.,mass_csp=0.,lbol_csp=0.,sfr=0.,mdust=0.,mformed=0.
      REAL(SP), DIMENSION(nbands) :: mags=0.
      REAL(SP), DIMENSION(nspec)  :: spec=0.
      REAL(SP), DIMENSION(nindx)  :: indx=0.

--- a/src/ztinterp.f90
+++ b/src/ztinterp.f90
@@ -12,7 +12,7 @@ SUBROUTINE ZTINTERP(zpos,spec,lbol,mass,tpos,zpow)
   REAL(SP),INTENT(in), OPTIONAL :: tpos,zpow
   REAL(SP),INTENT(inout),DIMENSION(:) :: mass, lbol
   REAL(SP),INTENT(inout),DIMENSION(:,:) :: spec
-  INTEGER  :: zlo,tlo,i
+  INTEGER  :: zlo,zhi,tlo,i
   REAL(SP) :: dz,dt,z0,imdf,w1=0.25,w2=0.5,w3=0.25
   REAL(SP), DIMENSION(nz) :: mdf
 
@@ -80,18 +80,21 @@ SUBROUTINE ZTINTERP(zpos,spec,lbol,mass,tpos,zpow)
            mdf(MIN(zlo+2,nz)) = w3*dz
            mdf(zlo)   = mdf(zlo) + w2*(1-dz) + w1*dz
            mdf(zlo+1) = mdf(zlo+1) + w3*(1-dz) + w2*dz
-           
+           zlo = zlo-1
+           zhi = zlo+2
         ELSE
            z0  = 10**zpos*zsol
            !mdf = ds/dlogZ
            mdf = ( zlegend/z0 * EXP(-zlegend/z0) )**zpow
+           zlo = 1
+           zhi = nz
         ENDIF
         mdf = mdf / SUM(mdf)
 
         mass = 0.
         lbol = 0.
         spec = 0.
-        DO i=1,nz
+        DO i=zlo,zhi
            mass = mass + mdf(i)*mass_ssp_zz(:,i)
            lbol = lbol + mdf(i)*lbol_ssp_zz(:,i)
            spec = spec + mdf(i)*spec_ssp_zz(:,:,i)

--- a/src/ztinterp.f90
+++ b/src/ztinterp.f90
@@ -80,8 +80,8 @@ SUBROUTINE ZTINTERP(zpos,spec,lbol,mass,tpos,zpow)
            mdf(MIN(zlo+2,nz)) = w3*dz
            mdf(zlo)   = mdf(zlo) + w2*(1-dz) + w1*dz
            mdf(zlo+1) = mdf(zlo+1) + w3*(1-dz) + w2*dz
-           zlo = zlo-1
-           zhi = zlo+2
+           zlo = max(zlo-1, 1)
+           zhi = min(zlo+2, nz)
         ELSE
            z0  = 10**zpos*zsol
            !mdf = ds/dlogZ


### PR DESCRIPTION
This PR (re-)implements a number of features and contains minor bug fixes and speed-enhancements.

- Metallicity evolution in tabular SFHs is supported again if `nzin > 1`

- Light- and mass-weighted quantities are calculated if `compute_light_ages=1` in `sps_vars.f90`.  This means that the output spectra are actually the light-weighted age at each wavelength, the output mags are transmission-weighted averages of these, the output lbol is the bolometric luminosity weighted age, and the output mass is the mass-weighted age.

- A new field in the `compspout` structure called `mformed` stores the integral of the SFH, useful for `tage=0` and comparing it to `tage !=0` output.

- Speed improvement for computing SSPs with triangular smoothing in `ztinterp`.

- minor bugfixes for very young bursts, for redshift_colors behavior, and for compsp warnings.