### PR TITLE
smooth_lsf fixes

### DIFF
--- a/src/autosps.f90
+++ b/src/autosps.f90
@@ -132,7 +132,7 @@ PROGRAM AUTOSPS
   ELSE
      READ(aux,'(A)') file1
   ENDIF
-  WRITE(6,'(" ---> Output filename:",1x,A100)'),file1
+  WRITE(6,'(" ---> Output filename:",1x,A100)') file1
 
 
   WRITE(6,'(" ---> Running model.......")')

--- a/src/smoothspec.f90
+++ b/src/smoothspec.f90
@@ -44,7 +44,10 @@ SUBROUTINE SMOOTHSPEC(lambda,spec,sigma,minl,maxl,ires)
            
            IF (PRESENT(ires)) THEN
               sigmal = ires(i)
-              IF (sigmal.LE.tiny_number) CYCLE
+              IF (sigmal.LE.tiny_number) THEN
+                 spec(i)=tspec(i)
+                 CYCLE
+              ENDIF
            ELSE
               sigmal = sigma
            ENDIF


### PR DESCRIPTION
Keeps smoothspec from zeroing out the spectrum when velocity dispersion is zero in lsf.dat

Also minor change in autosps for modern syntax