### PR TITLE
only produce a COMPSP error if age < 0

### DIFF
--- a/src/compsp.f90
+++ b/src/compsp.f90
@@ -193,7 +193,7 @@ SUBROUTINE COMPSP_WARNING(maxtime,pset,nzin,write_compsp)
 
   !-----------------------------------------------------!
 
-  IF (maxtime.LE.1E8.AND.pset%sfh.NE.0) THEN
+  IF (maxtime.LE.0.AND.pset%sfh.NE.0) THEN
      WRITE(*,*) 'COMPSP ERROR, maxtime too small:',maxtime
      STOP
   ENDIF


### PR DESCRIPTION
gets rid of old constraint that tage > 100 Myr, unnecessary now that SFH convolution integrals are analytic.