### PR TITLE
allow 'agb' parameter to modify the TP-AGB weights.

### DIFF
--- a/src/mod_gb.f90
+++ b/src/mod_gb.f90
@@ -1,4 +1,4 @@
-SUBROUTINE MOD_GB(zz,t,age,delt,dell,pagb,redgb,&
+SUBROUTINE MOD_GB(zz,t,age,delt,dell,pagb,redgb,agb,&
      nn,logl,logt,phase,wght)
 
   !routine to modify TP-AGB stars, HB+RGB, and post-AGB stars. 
@@ -10,7 +10,7 @@ SUBROUTINE MOD_GB(zz,t,age,delt,dell,pagb,redgb,&
   REAL(SP), INTENT(inout), DIMENSION(nt,nm) :: logl,logt
   REAL(SP), INTENT(in), DIMENSION(nt,nm)    :: phase
   REAL(SP), INTENT(inout), DIMENSION(nm)    :: wght
-  REAL(SP), INTENT(in) :: delt, dell, pagb,redgb
+  REAL(SP), INTENT(in) :: delt, dell, pagb, redgb, agb
   REAL(SP), INTENT(in), DIMENSION(nt) :: age
   INTEGER  :: i
   REAL(SP) :: age8=8.0_sp,age91=9.1_sp,twght
@@ -49,6 +49,9 @@ SUBROUTINE MOD_GB(zz,t,age,delt,dell,pagb,redgb,&
            ENDIF
 
         ENDIF
+
+        ! modify wght of tp-agb stars
+        wght(i) = wght(i)*agb
 
         !add extra fudge factors to the default normalization
         logl(t,i) = logl(t,i) + dell

--- a/src/sbf.f90
+++ b/src/sbf.f90
@@ -67,7 +67,7 @@ SUBROUTINE SBF(pset,outfile)
 
      !modify the TP-AGB stars and Post-AGB stars
      CALL MOD_GB(pset%zmet,i,time,pset%delt,pset%dell,pset%pagb,&
-          pset%redgb,nmass(i),logl,logt,phase,wght)
+          pset%redgb,pset%agb,nmass(i),logl,logt,phase,wght)
  
      spec1 = 0.0
      spec2 = 0.0

--- a/src/sps_utils.f90
+++ b/src/sps_utils.f90
@@ -258,14 +258,14 @@ MODULE SPS_UTILS
   END INTERFACE
 
   INTERFACE
-     SUBROUTINE MOD_GB(zz,t,age,delt,dell,pagb,redgb,&
+     SUBROUTINE MOD_GB(zz,t,age,delt,dell,pagb,redgb,agb,&
           nn,logl,logt,phase,wght)
        USE sps_vars
        INTEGER,  INTENT(in) :: t, nn,zz
        REAL(SP), INTENT(inout), DIMENSION(nt,nm) :: logl,logt
        REAL(SP), INTENT(in), DIMENSION(nt,nm)    :: phase
        REAL(SP), INTENT(inout), DIMENSION(nm)    :: wght
-       REAL(SP), INTENT(in) :: delt, dell, pagb,redgb
+       REAL(SP), INTENT(in) :: delt, dell, pagb,redgb, agb
        REAL(SP), INTENT(in), DIMENSION(nt) :: age
      END SUBROUTINE MOD_GB
   END INTERFACE

--- a/src/ssp_gen.f90
+++ b/src/ssp_gen.f90
@@ -165,7 +165,7 @@ SUBROUTINE SSP_GEN(pset,mass_ssp,lbol_ssp,spec_ssp)
 
      !modify the TP-AGB stars and Post-AGB stars
      CALL MOD_GB(pset%zmet,i,time,pset%delt,pset%dell,pset%pagb,&
-          pset%redgb,nmass(i),logl,logt,phase,wght)
+          pset%redgb,pset%agb,nmass(i),logl,logt,phase,wght)
 
      ii = 1 + (i-1)*time_res_incr
 

--- a/src/write_isochrone.f90
+++ b/src/write_isochrone.f90
@@ -65,7 +65,7 @@ SUBROUTINE WRITE_ISOCHRONE(outfile,pset)
 
      !modify the RGB and/or AGB stars
      CALL MOD_GB(zz,tt,timestep_isoc(zz,:),pset%delt,&
-          pset%dell,pset%pagb,pset%redgb,nmass(tt),logl,logt,phase,wght)
+          pset%dell,pset%pagb,pset%redgb,pset%agb,nmass(tt),logl,logt,phase,wght)
 
      DO i=1,nmass(tt)
         


### PR DESCRIPTION
This allows the (currently unused) `agb` parameter to scale up and down the TP-AGB weights in `ssp_gen.f90`