### PR TITLE
enable build parallelism and integration with other build systems

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -28,10 +28,7 @@ F90 = gfortran
 # Compiler Optimizations
 #  (Uncomment only one)
 #========================
-# GNU (version < 4.3.0)
-F90FLAGS = -O -cpp
-# GNU (version >= 4.3.0)
-#F90FLAGS = -O3 -march=native -cpp
+F90FLAGS := -O3 -cpp $(F90FLAGS) # prepend so a user can set -Ofast from outside the Makefile
 #---------------------
 # Intel (Itanium 2 processor)
 #F90FLAGS = -O3 -mcpu=itanium2 -cpp
@@ -56,31 +53,23 @@ clean :
 	rm -rf *.o *.mod *.MOD *~
 
 autosps : autosps.o $(COMMON)
-	$(F90) -o autosps.exe autosps.o $(COMMON)
+	$(F90) $(F90FLAGS) -o autosps.exe autosps.o $(COMMON)
 
 simple : simple.o $(COMMON)
-	$(F90) -o simple.exe simple.o $(COMMON)
+	$(F90) $(F90FLAGS) -o simple.exe simple.o $(COMMON)
 
 lesssimple : lesssimple.o $(COMMON)
-	$(F90) -o lesssimple.exe lesssimple.o $(COMMON)
+	$(F90) $(F90FLAGS) -o lesssimple.exe lesssimple.o $(COMMON)
 
 spec_bin : spec_bin.o sps_vars.o
-	$(F90) -o spec_bin.exe spec_bin.o sps_vars.o
+	$(F90) $(F90FLAGS) -o spec_bin.exe spec_bin.o sps_vars.o
 
-autosps.o : sps_vars.o sps_utils.o
+sps_vars.o : sps_vars.f90
+	$(F90) $(F90FLAGS) sps_vars.f90 -c
 
-simple.o : sps_vars.o  sps_utils.o
+sps_utils.o : sps_utils.f90 sps_vars.o
+	$(F90) $(F90FLAGS) sps_utils.f90 -c
 
-lesssimple.o : sps_vars.o sps_utils.o
-
-spec_bin.o : sps_vars.o sps_utils.o
-
-sps_utils.o :  sps_vars.o
-
-%.o : %.f90
+%.o : %.f90 sps_vars.o sps_utils.o
 	$(F90) $(F90FLAGS) -o $@ -c $<
-
-%.o : nr/%.f90
-	$(F90) $(F90FLAGS) -o $@ -c $<
-
 

--- a/src/sps_vars.f90
+++ b/src/sps_vars.f90
@@ -6,20 +6,45 @@ MODULE SPS_VARS
   SAVE
 
 !-------set the spectral library------!
+#ifndef MILES
 #define MILES 1
+#endif
+
+#ifndef BASEL
 #define BASEL 0
+#endif
+
 ! "C3K" currently under development.  do not use.
+#ifndef C3K
 #define C3K 0
+#endif
 
 !------set the isochrone library------!
+#ifndef MIST
 #define MIST 1
+#endif
+
+#ifndef PADOVA
 #define PADOVA 0
+#endif
+
+#ifndef PARSEC
 #define PARSEC 0
+#endif
+
+#ifndef BASTI
 #define BASTI 0
+#endif
+
+#ifndef GENEVA
 #define GENEVA 0
+#endif
+
 !note that in the case of BPASS the SSPs are already pre-computed
 !so the spectral library, IMF, etc. is fixed in this case.  
+#ifndef BPASS
 #define BPASS 0
+#endif
   
   !--------------------------------------------------------------!
   !--------------------------------------------------------------!


### PR DESCRIPTION
The end goal here is to simplify the installation for [powderday](https://bitbucket.org/desika/powderday/) or any other project that depends directly or indirectly on FSPS. These changes should make the installation simpler, faster, and easier for tools to customize.