### PR TITLE
call add_dust for WG curves even if dust1=dust2=0.

### DIFF
--- a/src/csp_gen.f90
+++ b/src/csp_gen.f90
@@ -27,7 +27,7 @@ subroutine csp_gen(mass_ssp, lbol_ssp, spec_ssp, &
   
   use sps_vars, only: ntfull, nspec, time_full, tiny_number, tiny_logt, &
                       zlegend, nz, sfh_tab, ntabsfh, compute_light_ages, &
-                      SFHPARAMS, PARAMS, SP,nemline
+                      SFHPARAMS, PARAMS, SP, nemline, dust_type
   use sps_utils, only: locate, sfh_weight, sfhinfo, add_dust
   implicit none
 
@@ -263,7 +263,7 @@ subroutine csp_gen(mass_ssp, lbol_ssp, spec_ssp, &
   lbol_csp = log10(sum(10**lbol_ssp * total_weights))
 
   ! Here we add young and old spectra with dust.
-  if (((pset%dust1.gt.tiny_number).or.(pset%dust2.gt.tiny_number))&
+  if (((pset%dust1.gt.tiny_number).or.(pset%dust2.gt.tiny_number).or.(dust_type.eq.3))&
        .and.(compute_light_ages.eq.0)) then
      call add_dust(pset, csp1, csp2, spec_csp, mdust_csp, ncsp1, ncsp2, emlin_csp)
 


### PR DESCRIPTION
This fixes a bug where csp_gen would not compute dust effects for WG curves (`dust_type=3`) if `dust1=dust=0` (the defaults) even though the `dust` parameters do not control the WG curves.