### PR TITLE
Revert "updated mod_hb treatment for MIST"

### DIFF
--- a/src/getspec.f90
+++ b/src/getspec.f90
@@ -15,7 +15,7 @@ SUBROUTINE GETSPEC(pset,mact,logt,lbol,logg,phase,ffco,lmdot,wght,spec)
   REAL(SP), INTENT(inout), DIMENSION(nspec) :: spec  
   REAL(SP), DIMENSION(nspec) :: ispec
   REAL(SP) :: t,u,r2,test1,test2,test3,test4,loggi,teffi,rwr,twr
-  INTEGER  :: klo,jlo,flag,i
+  INTEGER  :: klo,jlo,flag
 
   !---------------------------------------------------------------!
   !---------------------------------------------------------------!
@@ -147,7 +147,7 @@ SUBROUTINE GETSPEC(pset,mact,logt,lbol,logg,phase,ffco,lmdot,wght,spec)
   ELSE
 
      flag = flag+1
-     
+
      !find the subgrid containing point i 
      jlo = MIN(MAX(locate(speclib_logt,logt),1),ndim_logt-1)
      klo = MIN(MAX(locate(speclib_logg,loggi),1),ndim_logg-1)
@@ -170,7 +170,7 @@ SUBROUTINE GETSPEC(pset,mact,logt,lbol,logg,phase,ffco,lmdot,wght,spec)
      IF ((test1.LE.tiny30.OR.test2.LE.tiny30.OR.&
           test3.LE.tiny30.OR.test4.LE.tiny30).AND.flag.EQ.1) THEN
 
-        IF (verbose.EQ.1) & 
+        IF (verbose.EQ.99) & 
              WRITE(*,'(" GETSPEC WARNING: Part of the '//&
              'point is off the grid: Z=",I2,'//&
              '" logT=",F5.2," logg=",F5.2," phase=",I2," lg IMF*L=",F5.2)') &
@@ -182,15 +182,6 @@ SUBROUTINE GETSPEC(pset,mact,logt,lbol,logg,phase,ffco,lmdot,wght,spec)
         IF (test3.GT.tiny30) ispec = speclib(:,pset%zmet,jlo,klo+1)
         IF (test4.GT.tiny30) ispec = speclib(:,pset%zmet,jlo+1,klo+1)
 
-   !     DO i=1000,5180
-   !        WRITE(88,*) spec_lambda(i),speclib(i,pset%zmet,34,17),&
-   !             speclib(i,pset%zmet,38,17),speclib(i,pset%zmet,42,17),&
-   !             speclib(i,pset%zmet,46,17),speclib(i,pset%zmet,50,17),&
-   !             speclib(i,pset%zmet,55,17),speclib(i,pset%zmet,60,17),&
-   !             speclib(i,pset%zmet,65,17)
-   !     ENDDO
-   !     STOP
-        
      ELSE
 
         !bilinear interpolation
@@ -198,7 +189,7 @@ SUBROUTINE GETSPEC(pset,mact,logt,lbol,logg,phase,ffco,lmdot,wght,spec)
              t*(1-u)*speclib(:,pset%zmet,jlo+1,klo) + &
              t*u*speclib(:,pset%zmet,jlo+1,klo+1) + &
              (1-t)*u*speclib(:,pset%zmet,jlo,klo+1)
-        
+
      ENDIF
 
      !at long last the extra factor of 4pi (below) has been found!
@@ -213,7 +204,7 @@ SUBROUTINE GETSPEC(pset,mact,logt,lbol,logg,phase,ffco,lmdot,wght,spec)
   IF (verbose.EQ.1) THEN
      !IF (flag.EQ.0.AND.(spec_type.EQ.'basel'.OR.spec_type.EQ.'ckc14').AND.&
      !     phase.NE.6.AND.phase.NE.9) THEN
-     IF (flag.EQ.0..AND.wght.GT.0.0.AND.phase.GT.-1) THEN
+     IF (flag.EQ.0..AND.wght.GT.0.0) THEN
         WRITE(*,'(" GETSPEC WARNING: point entirely off the grid: Z=",I2,'//&
              '" logT=",F5.2," logg=",F5.2," phase=",I2," lg IMF*L=",F5.2)') &
             pset%zmet,logt,loggi,INT(phase),LOG10(wght*lbol)

--- a/src/mod_hb.f90
+++ b/src/mod_hb.f90
@@ -49,10 +49,7 @@ SUBROUTINE MOD_HB(f_bhb,t,mini,mact,logl,logt,logg,phase, &
      DO i=1,nm
         IF (tphase(i).EQ.3) THEN
            tnhb=tnhb+1
-           !need this delta(mass) cut to remove the stars 
-           !descending from the TRGB in the MIST models
-           IF (logt(t,i).LT.minteff.AND.(mini(t,i+1)-mini(t,i)).GT.1E-6)  &
-                minteff=logt(t,i)
+           IF (logt(t,i).LT.minteff)  minteff=logt(t,i)
         ENDIF
      ENDDO
      i=1

--- a/src/sps_setup.f90
+++ b/src/sps_setup.f90
@@ -120,7 +120,7 @@ SUBROUTINE SPS_SETUP(zin)
      OPEN(90,FILE=TRIM(SPS_HOME)//'/ISOCHRONES/BaSTI/zlegend'//&
           '.dat',STATUS='OLD',iostat=stat,ACTION='READ')
   ELSE IF (isoc_type.EQ.'mist') THEN
-     OPEN(90,FILE=TRIM(SPS_HOME)//'/ISOCHRONES/MIST/MIST2_zlegend'//&
+     OPEN(90,FILE=TRIM(SPS_HOME)//'/ISOCHRONES/MIST/zlegend'//&
           '.dat',STATUS='OLD',iostat=stat,ACTION='READ')
   ELSE IF (isoc_type.EQ.'bpss') THEN
      OPEN(90,FILE=TRIM(SPS_HOME)//'/ISOCHRONES/BPASS/zlegend'//&
@@ -230,9 +230,9 @@ SUBROUTINE SPS_SETUP(zin)
      OPEN(93,FILE=TRIM(SPS_HOME)//'/SPECTRA/MILES/zlegend.dat',&
           STATUS='OLD',iostat=stat,ACTION='READ')
   ELSE IF (spec_type(1:5).EQ.'ckc14') THEN
-     OPEN(91,FILE=TRIM(SPS_HOME)//'/SPECTRA/CKC14/'//spec_type//'_'//afestr//'.lambda',&
+     OPEN(91,FILE=TRIM(SPS_HOME)//'/SPECTRA/CKC14/'//spec_type//'.lambda',&
           STATUS='OLD',iostat=stat,ACTION='READ')
-     OPEN(93,FILE=TRIM(SPS_HOME)//'/SPECTRA/CKC14/'//spec_type//'_'//afestr//'_zlegend.dat',&
+     OPEN(93,FILE=TRIM(SPS_HOME)//'/SPECTRA/CKC14/zlegend.dat',&
           STATUS='OLD',iostat=stat,ACTION='READ')
   ENDIF
   IF (stat.NE.0) THEN
@@ -278,7 +278,7 @@ SUBROUTINE SPS_SETUP(zin)
              STATUS='OLD',iostat=stat,ACTION='READ',access='direct',&
              recl=nspec*ndim_logg*ndim_logt*4)
      ELSE IF (spec_type(1:5).EQ.'ckc14') THEN
-        OPEN(92,FILE=TRIM(SPS_HOME)//'/SPECTRA/CKC14/'//spec_type//'_'//afestr//'_z'&
+        OPEN(92,FILE=TRIM(SPS_HOME)//'/SPECTRA/CKC14/'//spec_type//'_z'&
              //zstype//'.spectra.bin',FORM='UNFORMATTED',&
              STATUS='OLD',iostat=stat,ACTION='READ',access='direct',&
              recl=nspec*ndim_logg*ndim_logt*4)
@@ -664,8 +664,8 @@ SUBROUTINE SPS_SETUP(zin)
           zstype//'.dat',STATUS='OLD', IOSTAT=stat,ACTION='READ')
      !open MIST isochrones
      IF (isoc_type.EQ.'mist') OPEN(97,FILE=TRIM(SPS_HOME)//&
-          '/ISOCHRONES/MIST/isoc_MIST2_z'//zlegend_str(z)//'_'//afestr//'.dat',&
-          STATUS='OLD',IOSTAT=stat,ACTION='READ')
+          '/ISOCHRONES/MIST/isoc_z'//zlegend_str(z)//'.dat',STATUS='OLD',&
+          IOSTAT=stat,ACTION='READ')
      !open BaSTI isochrones
      IF (isoc_type.EQ.'bsti') OPEN(97,FILE=TRIM(SPS_HOME)//&
           '/ISOCHRONES/BaSTI/isoc_z'//zstype//'.dat',STATUS='OLD',&

--- a/src/sps_vars.f90
+++ b/src/sps_vars.f90
@@ -7,16 +7,16 @@ MODULE SPS_VARS
 
 !-------set the spectral library------!
 #ifndef MILES
-#define MILES 0
+#define MILES 1
 #endif
 
 #ifndef BASEL
 #define BASEL 0
 #endif
 
-! "CKC14" currently under development.  do not use.
-#ifndef CKC14
-#define CKC14 1
+! "C3K" currently under development.  do not use.
+#ifndef C3K
+#define C3K 0
 #endif
 
 !------set the isochrone library------!
@@ -49,8 +49,6 @@ MODULE SPS_VARS
   !--------------------------------------------------------------!
   !--------------------------------------------------------------!
 
-  CHARACTER(7), PARAMETER :: afestr = 'afe+0.0'
-  
   !note that "SP" actually means double precision; this is a hack
   !to turn the nr routines into DP
   INTEGER, PARAMETER :: SP = KIND(1.d0)
@@ -239,11 +237,11 @@ MODULE SPS_VARS
   CHARACTER(5), PARAMETER :: spec_type = 'miles'
   INTEGER, PARAMETER :: nzinit=5
   INTEGER, PARAMETER :: nspec=5994
-#elif (CKC14)
+#elif (C3K)
   REAL(SP), PARAMETER :: zsol_spec = 0.0134
   CHARACTER(5), PARAMETER :: spec_type = 'ckc14'
-  INTEGER, PARAMETER :: nzinit=11
-  INTEGER, PARAMETER :: nspec=8737 !47378  !46666 !47378 !, 26500
+  INTEGER, PARAMETER :: nzinit=6
+  INTEGER, PARAMETER :: nspec=47378  !46666 !47378 !, 26500
 #elif (BASEL)
   REAL(SP), PARAMETER :: zsol_spec = 0.020
   CHARACTER(5), PARAMETER :: spec_type = 'basel'


### PR DESCRIPTION
Undo changes to isochrone and stellar library file names, as well as the HB modification. Reverts 1e2771f.