### PR TITLE
Fix mweights

### DIFF
--- a/src/compsp.f90
+++ b/src/compsp.f90
@@ -22,10 +22,9 @@ SUBROUTINE COMPSP(write_compsp, nzin, outfile,&
   REAL(SP), DIMENSION(nspec, ntfull, nzin)   :: spec_ssp
   REAL(SP), DIMENSION(nemline, ntfull, nzin) :: emlin_ssp
   REAL(SP), DIMENSION(nemline) :: emlin_csp
-  REAL(SP), dimension(ntfull) :: mdust_ssp
   REAL(SP) :: lbol_csp, mass_csp, mdust_csp
-  REAL(SP) :: age, mdust, mass_frac, tsfr, zred, frac_linear, maxtime
-  REAL(SP), DIMENSION(nspec) :: csp1, csp2, spec_dusty, spec_csp
+  REAL(SP) :: age, mass_frac, tsfr, zred, frac_linear, maxtime
+  REAL(SP), DIMENSION(nspec) :: spec_csp
   REAL(SP), DIMENSION(nbands)  :: mags
   REAL(SP), DIMENSION(nindx)   :: indx
   INTEGER :: i, nage

--- a/src/compsp.f90
+++ b/src/compsp.f90
@@ -203,7 +203,7 @@ SUBROUTINE COMPSP_WARNING(maxtime,pset,nzin,write_compsp)
 
   !the isochrones don't go past 10**10.15 yrs, so warn the user
   !that this will be an extrapolation
-  IF (maxtime.GT.10**10.2.AND.isoc_type.NE.'mist') THEN
+  IF ((maxtime.GT.10**10.2).AND.(isoc_type.NE.'mist').AND.(isoc_type.NE.'bpss')) THEN
      WRITE(*,*) 'COMPSP WARNING: log(Tmax)>10.2 yrs -'//&
           ' linear extrapolation beyond this point for log(Tmax)=:',&
           LOG10(maxtime)

--- a/src/compsp.f90
+++ b/src/compsp.f90
@@ -8,7 +8,7 @@ SUBROUTINE COMPSP(write_compsp, nzin, outfile,&
   use sps_utils, only: write_isochrone, add_nebular, setup_tabular_sfh, &
                        csp_gen, sfhinfo, linterp, agn_dust, &
                        smoothspec, igm_absorb, getindx, getmags
-                       
+
   implicit none
 
   INTEGER, INTENT(in) :: write_compsp,nzin
@@ -52,7 +52,7 @@ SUBROUTINE COMPSP(write_compsp, nzin, outfile,&
   else
      maxtime = 10**time_full(ntfull)
   endif
-  
+
   CALL COMPSP_WARNING(maxtime, pset, nzin, write_compsp)
 
   ! Setup output files
@@ -82,7 +82,7 @@ SUBROUTINE COMPSP(write_compsp, nzin, outfile,&
   if (add_neb_emission.EQ.1) then
      if (nzin.GT.1) then
         WRITE(*,*) 'COMPSP ERROR: cannot handle both nebular '//&
-             'emission and mult-metallicity SSPs in compsp'
+             'emission and multi-metallicity SSPs in compsp'
         STOP
      endif
      call add_nebular(pset, tspec_ssp(:,:,1), spec_ssp(:,:,1), emlin_ssp(:,:,1))
@@ -92,7 +92,7 @@ SUBROUTINE COMPSP(write_compsp, nzin, outfile,&
 
 
   ! --- Get CSP spectra -------
-  
+
   ! Loop over output ages.
   do i=1,ntfull
      ! ------
@@ -116,9 +116,9 @@ SUBROUTINE COMPSP(write_compsp, nzin, outfile,&
      call csp_gen(mass_ssp, lbol_ssp, spec_ssp, &
           pset, age, nzin, mass_csp, lbol_csp, spec_csp,&
           mdust_csp,emlin_ssp,emlin_csp)
-     
+
      call sfhinfo(pset, age, mass_frac, tsfr, frac_linear)
-     if (pset%tage.le.0) then   
+     if (pset%tage.le.0) then
         mass_csp  = mass_csp * mass_frac
         lbol_csp  = log10(10**lbol_csp * mass_frac)
         spec_csp  = spec_csp * mass_frac
@@ -233,7 +233,6 @@ SUBROUTINE COMPSP_WARNING(maxtime,pset,nzin,write_compsp)
           ' sf_trunc will be ignored.'
   ENDIF
 
-  
   !set limits on the parameters tau and const
   IF (pset%sfh.EQ.1.OR.pset%sfh.EQ.4) THEN
      IF (pset%tau.LE.0.1.AND.pset%tau.GE.0.0) THEN
@@ -299,7 +298,7 @@ SUBROUTINE COMPSP_WARNING(maxtime,pset,nzin,write_compsp)
      WRITE(*,*) 'COMPSP WARNING: compute_light_ages does not take into'//&
           ' account age-dependent dust (dust1 > 0)'
   ENDIF
-     
+
 
 END SUBROUTINE COMPSP_WARNING
 
@@ -324,7 +323,7 @@ SUBROUTINE COMPSP_SETUP_OUTPUT(write_compsp,pset,outfile,imin,imax)
           STATUS='REPLACE')
      CALL COMPSP_HEADER(10,pset)
   ENDIF
-  
+
   !open output file for spectra
   IF (write_compsp.EQ.2.OR.write_compsp.EQ.3) THEN
      OPEN(20,FILE=TRIM(SPS_HOME)//'/OUTPUTS/'//TRIM(outfile)//'.spec',&

--- a/src/compsp.f90
+++ b/src/compsp.f90
@@ -129,9 +129,10 @@ SUBROUTINE COMPSP(write_compsp, nzin, outfile,&
         tsfr = tsfr / mass_frac
         mass_frac = 1.0
      endif
-     if ((pset%sfh.eq.2).or.(pset%sfh)) then
+     if ((pset%sfh.eq.2).OR.(pset%sfh.eq.3)) then
         ! get mass formed from sum of SSP weights
         mass_frac = sum(weight_ssp)
+     endif
 
      ! -------
      ! Now do a bunch of stuff with the spectrum

--- a/src/compsp.f90
+++ b/src/compsp.f90
@@ -129,6 +129,9 @@ SUBROUTINE COMPSP(write_compsp, nzin, outfile,&
         tsfr = tsfr / mass_frac
         mass_frac = 1.0
      endif
+     if ((pset%sfh.eq.2).or.(pset%sfh)) then
+        ! get mass formed from sum of SSP weights
+        mass_frac = sum(weight_ssp)
 
      ! -------
      ! Now do a bunch of stuff with the spectrum

--- a/src/csp_gen.f90
+++ b/src/csp_gen.f90
@@ -106,7 +106,7 @@ subroutine csp_gen(mass_ssp, lbol_ssp, spec_ssp, &
      total_weights(:, 1) = total_weights(:, 1) / m1
   endif
 
-  
+
   ! Add constant and burst weights for SFH=1,4
   if (((pset%sfh.eq.1).or.(pset%sfh.eq.4)).and.&
        ((pset%const.gt.0).or.(pset%fburst.gt.tiny_number))) then
@@ -134,7 +134,7 @@ subroutine csp_gen(mass_ssp, lbol_ssp, spec_ssp, &
                           fburst * w2
   endif
 
-  
+
   ! Simha
   if (pset%sfh.eq.5) then
      imin = 0
@@ -324,10 +324,10 @@ subroutine convert_sfhparams(pset, tage, sfh)
   !
   use sps_vars, only: tiny_number, SFHPARAMS, PARAMS, SP
   implicit none
-  
+
   type(PARAMS), intent(in) :: pset
   real(SP), intent(in) :: tage
-  
+
   type(SFHPARAMS), intent(inout) :: sfh
 
   real(SP) :: start
@@ -350,7 +350,7 @@ subroutine convert_sfhparams(pset, tage, sfh)
 
   ! convert tburst to lookback time
   sfh%tb = sfh%tage - sfh%tburst
-  
+
   ! convert sf_trunc to to lookback time
   if ((sfh%sf_trunc.le.0).or.(sfh%sf_trunc.gt.sfh%tage)) then
      sfh%tq = 0.

--- a/src/csp_gen.f90
+++ b/src/csp_gen.f90
@@ -1,6 +1,6 @@
 subroutine csp_gen(mass_ssp, lbol_ssp, spec_ssp, &
      pset, tage, nzin, mass_csp, lbol_csp, spec_csp, &
-     mdust_csp,emlin_ssp,emlin_csp)
+     mdust_csp,emlin_ssp,emlin_csp)!,total_weights)
   !
   ! Return the spectrum (and mass and lbol) of a composite stellar population.
   !
@@ -18,16 +18,25 @@ subroutine csp_gen(mass_ssp, lbol_ssp, spec_ssp, &
   !   The age (in Gyr of forward time) at which the spectrum is desired.  Note
   !   that this can be different than pset%tage if the latter is 0.
   !
+  ! emlin_ssp:
+  !   The emission line luminosities for each SSP
+  !
   ! Outputs
   ! ---------
   !
   ! mass_csp, lbol_csp, spec_csp:
   !   The (surviving) stellar masses, bolometric luminosity, and spectrum of
   !   the composite stellar population at tage, normalized to 1 M_sun *formed*.
-  
+  !
+  ! emlin_csp:
+  !   The emission line luminosities for the CSP
+  !
+  ! total_weights:
+  !    The weights(masses) for each SSP in the composite
+
   use sps_vars, only: ntfull, nspec, time_full, tiny_number, tiny_logt, &
                       zlegend, nz, sfh_tab, ntabsfh, compute_light_ages, &
-                      SFHPARAMS, PARAMS, SP, nemline, dust_type
+                      SFHPARAMS, PARAMS, SP, nemline, dust_type, weight_ssp
   use sps_utils, only: locate, sfh_weight, sfhinfo, add_dust
   implicit none
 
@@ -36,12 +45,14 @@ subroutine csp_gen(mass_ssp, lbol_ssp, spec_ssp, &
   type(PARAMS), intent(in) :: pset
   real(SP), intent(in) :: tage
   integer, intent(in) :: nzin
-  
+
   real(SP), intent(out) :: mass_csp, lbol_csp, mdust_csp
   real(SP), intent(out), dimension(nspec) :: spec_csp
 
   real(SP), DIMENSION(nemline, ntfull, nzin), intent(in) :: emlin_ssp
   real(SP), DIMENSION(nemline), intent(out) :: emlin_csp
+
+  !real(SP), intent(out), dimension(ntfull, nzin) :: total_weights
 
   real(SP), dimension(nspec) :: csp1, csp2, lw_age
   real(SP), dimension(nemline) :: ncsp1, ncsp2, nlw_age
@@ -67,6 +78,7 @@ subroutine csp_gen(mass_ssp, lbol_ssp, spec_ssp, &
   ! ----- Get SFH weights -----
 
   total_weights = 0.
+  weight_ssp = 0.
 
   ! SSP.
   if (pset%sfh.eq.0) then
@@ -238,6 +250,7 @@ subroutine csp_gen(mass_ssp, lbol_ssp, spec_ssp, &
   do i=max(imin, 1), imax
      do k=1,nzin
         if (total_weights(i, k).gt.tiny_number) then
+           weight_ssp(i, k) = total_weights(i, k)  ! copy to common variable
            if (i.le.i_tesc) then
               csp1  = csp1  + total_weights(i, k) * spec_ssp(:, i, k)
               ncsp1 = ncsp1 + total_weights(i, k) * emlin_ssp(:, i, k)

--- a/src/setup_tabular_sfh.f90
+++ b/src/setup_tabular_sfh.f90
@@ -19,14 +19,14 @@ subroutine setup_tabular_sfh(pset, nzin)
   type(PARAMS), intent(in) :: pset
   integer, intent(in) :: nzin
   integer :: stat, n
-  
+
   IF (pset%sfh.EQ.2) THEN
 
-     if (pset%sf_start.gt.tiny_number) then 
+     if (pset%sf_start.gt.tiny_number) then
         WRITE(*,*) 'COMPSP ERROR: Tabular sfh, but sf_start > 0'
         STOP
      endif
-     
+
      ! Read the sfh file
      IF (TRIM(pset%sfh_filename).EQ.'') THEN
         OPEN(3,FILE=TRIM(SPS_HOME)//'/data/sfh.dat',ACTION='READ',STATUS='OLD')
@@ -49,18 +49,17 @@ subroutine setup_tabular_sfh(pset, nzin)
 29   CONTINUE
      CLOSE(3)
 
-     
      ntabsfh = n-1
-     sfh_tab(1,1:ntabsfh) = sfh_tab(1,1:ntabsfh)*1E9 !convert to yrs        
-     
+     sfh_tab(1,1:ntabsfh) = sfh_tab(1,1:ntabsfh)*1E9 !convert to yrs
+
      !special switch to compute only the last time output
      !in the tabulated file
      ! IF (pset%tage.EQ.-99.) imin=imax
 
-  ELSE IF (pset%sfh.EQ.3) THEN 
+  ELSE IF (pset%sfh.EQ.3) THEN
 
      !sfh_tab array is supposed to already be filled in, check that it is
-     IF (ntabsfh.EQ.0) THEN 
+     IF (ntabsfh.EQ.0) THEN
         WRITE(*,*) 'COMPSP ERROR: sfh=3 but sfh_tab array not initialized!'
         STOP
      ENDIF
@@ -71,5 +70,5 @@ subroutine setup_tabular_sfh(pset, nzin)
   do n=1, ntabsfh
      sfh_tab(2, n) = max(sfh_tab(2, n), tiny30)
   enddo
-  
+
 end subroutine setup_tabular_sfh

--- a/src/sfh_weight.f90
+++ b/src/sfh_weight.f90
@@ -27,17 +27,17 @@ function sfh_weight(sfh, imin, imax)
                       SFHPARAMS, SP
   use sps_utils, only: intsfwght, sfhlimit, locate
   implicit none
-  
+
   type(SFHPARAMS), intent(in) :: sfh
   integer, intent(in) :: imin, imax
 
   real(SP), dimension(ntfull) ::sfh_weight
-  
+
   integer :: i, istart
   real(SP), dimension(2) :: tlim
   real(SP) :: dt, delta_time, log_tb
   real(SP), dimension(ntfull) :: tmp_wght=0. !left=0., right=0.
-  
+
 
   ! Check if this is an SSP.  If so, do simple weights and return.
   if (sfh%type.eq.-1) then
@@ -70,7 +70,7 @@ function sfh_weight(sfh, imin, imax)
      if (i.gt.1) then
         ! There is a younger (`left`) bin, and we calculate its contribution to
         ! the weight.
-        ! First calculate actual limits for the younger bin.  
+        ! First calculate actual limits for the younger bin.
         tlim(1) = sfhlimit(time_full(i-1), sfh)
         tlim(2) = sfhlimit(time_full(i), sfh)
         ! The elements of `tlim` will be equal if there is no valid SFR in the
@@ -117,7 +117,7 @@ function sfh_weight(sfh, imin, imax)
 
 end function sfh_weight
 
-  
+
 function delta_time(logt1, logt2)
   ! Dumb function to properly calculate dt based on interpolation type.
   !

--- a/src/sfhinfo.f90
+++ b/src/sfhinfo.f90
@@ -37,24 +37,24 @@ subroutine sfhinfo(pset, age, mfrac, sfr, frac_linear)
   real(SP), intent(in) :: age
 
   real(SP), intent(out) :: mfrac, sfr, frac_linear
-  
+
   real(SP) :: Tmax, Tprime, Tz, Ttrunc, Thi
   real(SP) :: m, gammainc
   real(SP) :: mass_tau, mass_linear, mfrac_burst
   real(SP) :: total_mass_tau, total_mass_linear
-  real(SP) :: sfr_tau, sfr_linear, sfr_trunc, sfr_const
+  real(SP) :: sfr_tau, sfr_trunc, sfr_const
   integer :: power, itab
 
   ! Defaults
   mfrac = 1.
   sfr = 0.
   frac_linear = 0.
-  
+
   if (pset%sfh.eq.0) then
      ! SSPs
      mfrac = 1.0
      sfr = 0. ! actually the sfr is infinity
-     
+
   else if ((pset%sfh.eq.1).or.(pset%sfh.eq.4).or.(pset%sfh.eq.5)) then
      ! Compute tau model component, for SFH=1,4,5
      !
@@ -181,10 +181,10 @@ subroutine sfhinfo(pset, age, mfrac, sfr, frac_linear)
      sfr = sfh_tab(2, itab) + m * (age*1e9 - sfh_tab(1, itab))
      sfr = max(sfr, 0.0) * 1e9 ! convert to per Gyr
   endif
-  
+
   ! Convert SFR from per Gyr to per year
   sfr = sfr / 1e9
-  
+
 end subroutine sfhinfo
 
 function gammainc(power, arg)

--- a/src/sfhlimit.f90
+++ b/src/sfhlimit.f90
@@ -15,14 +15,14 @@ function sfhlimit(tlim, sfh)
   !
   use sps_vars, only: tiny_logt, SFHPARAMS, SP
   implicit none
-  
+
   real(SP), intent(in) :: tlim
   type(SFHPARAMS), intent(in) :: sfh
 
   real(SP) :: sfhlimit
-  
+
   real(SP) :: tlo, thi
-  
+
   ! For the simha linear portion, we integrate from sf_trunc to tage or the
   ! zero crossing, whichever is smaller but still greater than sf_trunc.
   ! For everything else we integrate from 0 to tage or sf_trunc, whichever is
@@ -36,12 +36,12 @@ function sfhlimit(tlim, sfh)
      tlo = sfh%tq
      thi = sfh%tage
   endif
-  
+
   ! Convert to log, taking care of possible zeros.
   tlo = log10(max(tlo, 10**tiny_logt))
   thi = log10(max(thi, 10**tiny_logt))
-  
+
   ! Finally, clip proposed limit to the upper and lower value
   sfhlimit = MIN(MAX(tlim, tlo), thi)
-  
+
 end function sfhlimit

--- a/src/sps_vars.f90
+++ b/src/sps_vars.f90
@@ -40,7 +40,7 @@ MODULE SPS_VARS
 #endif
 
 !note that in the case of BPASS the SSPs are already pre-computed
-!so the spectral library, IMF, etc. is fixed in this case.  
+!so the spectral library, IMF, etc. is fixed in this case.
 #ifndef BPASS
 #define BPASS 0
 #endif
@@ -53,7 +53,7 @@ MODULE SPS_VARS
 #ifndef THEMIS
 #define THEMIS 0
 #endif
-  
+
   !--------------------------------------------------------------!
   !--------------------------------------------------------------!
 
@@ -414,7 +414,7 @@ MODULE SPS_VARS
 
   !array holding the Gordon et al. (2003) SMC extinction
   REAL(SP), DIMENSION(nspec) :: g03smcextn=0.
-  
+
   !Index for P(Z) distribution.  1=closed box;
   !P(Z) = z^zpow*exp(-z/pmetals)  (see pz_convol.f90)
   !pmetals set in PARAMS structure
@@ -491,7 +491,6 @@ MODULE SPS_VARS
   REAL(SP), DIMENSION(ndim_dustem,numin_dustem*2) :: dustem_dustem=0.
   REAL(SP), DIMENSION(nspec,nqpah_dustem,numin_dustem*2) :: dustem2_dustem=0.
 
-  
   !circumstellar AGB dust model (Villaume et al. 2015)
   REAL(SP), DIMENSION(nspec,2,nteff_dagb,ntau_dagb) :: flux_dagb=0.
   REAL(SP), DIMENSION(2,ntau_dagb)                  :: tau1_dagb=0.
@@ -531,10 +530,13 @@ MODULE SPS_VARS
 
   REAL(SP), DIMENSION(ntfull) :: time_full=0.
 
+  !array for ssp weights
+  REAL(SP), DIMENSION(ntfull,nz)       :: weight_ssp=0.
+
   !array for full BPASS SSPs
   REAL(SP), DIMENSION(nspec,nt,nz) :: bpass_spec_ssp=0.
   REAL(SP), DIMENSION(nt,nz)       :: bpass_mass_ssp=0.
-  
+
   !------------Define TYPE structures-------------!
 
   !structure for the set of parameters necessary to generate a model


### PR DESCRIPTION
Work in Progress/Do not merge

This PR has a some updates intended to fix the computation of formed mass for tabular SFHs, and expose the SSP weights from csp_gen in the common module (e.g. for access via python-FSPS). Also some cleanup of parameter checking and unused variables.

Needs some testing, and there might be a cleaner way to expose the ssp weights (e.g. as an output array of csp_gen and compsp)