### PR TITLE
Splitting module `use` commands onto separate lines

### DIFF
--- a/src/add_agb_dust.f90
+++ b/src/add_agb_dust.f90
@@ -96,7 +96,8 @@ SUBROUTINE ADD_AGB_DUST(weight,tspec,mact,logt,logl,logg,zz,&
   !then looks up the corresponding DUSTY model given the C/O
   !ratio and Teff.
   
-  USE sps_vars; USE sps_utils, ONLY: locate, smoothspec
+  USE sps_vars
+  USE sps_utils, ONLY: locate, smoothspec
   IMPLICIT NONE
 
   REAL(SP), DIMENSION(nspec), INTENT(inout) :: tspec

--- a/src/add_bs.f90
+++ b/src/add_bs.f90
@@ -16,7 +16,8 @@ SUBROUTINE ADD_BS(s_bs,t,mini,mact,logl,logt,logg,phase, &
   !Note that the parameter bhb_sbs_time, set in sps_vars.f90,
   !sets the turn-on time for this modification
 
-  USE sps_vars; USE sps_utils, ONLY : linterp
+  USE sps_vars
+  USE sps_utils, ONLY : linterp
   IMPLICIT NONE
 
   REAL(SP), INTENT(inout), DIMENSION(nt,nm) :: mini,mact,&

--- a/src/add_nebular.f90
+++ b/src/add_nebular.f90
@@ -3,7 +3,8 @@ SUBROUTINE ADD_NEBULAR(pset,sspi,sspo,nebemline)
   !routine to add nebular emission (both line and continuum)
   !to input SSPs (sspi).  Returns SSPs as output (sspo).
 
-  USE sps_vars; USE sps_utils, ONLY : locate,tsum
+  USE sps_vars
+  USE sps_utils, ONLY : locate,tsum
   IMPLICIT NONE
 
   INTEGER :: t,i,nti,a1,z1,u1

--- a/src/agn_dust.f90
+++ b/src/agn_dust.f90
@@ -1,6 +1,7 @@
 FUNCTION AGN_DUST(lam,spec,pset,lbol_csp)
 
-  USE sps_vars; USE sps_utils, ONLY: locate,attn_curve
+  USE sps_vars
+  USE sps_utils, ONLY: locate,attn_curve
   IMPLICIT NONE
 
   REAL(SP), DIMENSION(nspec), INTENT(in) :: lam,spec

--- a/src/autosps.f90
+++ b/src/autosps.f90
@@ -1,6 +1,7 @@
 PROGRAM AUTOSPS
 
-  USE sps_vars; USE sps_utils
+  USE sps_vars
+  USE sps_utils
   
   IMPLICIT NONE
 

--- a/src/get_lumdist.f90
+++ b/src/get_lumdist.f90
@@ -4,7 +4,8 @@ FUNCTION GET_LUMDIST(z)
   !assumes flat universe w/ only matter and lambda
   !assumes om0,ol0,H0 set in sps_vars.f90
   
-  USE sps_vars; USE sps_utils, ONLY : tsum
+  USE sps_vars
+  USE sps_utils, ONLY : tsum
   IMPLICIT NONE
   INTEGER :: i
   INTEGER, PARAMETER :: ii=10000

--- a/src/getmags.f90
+++ b/src/getmags.f90
@@ -6,7 +6,8 @@ SUBROUTINE GETMAGS(zred,spec,mags,mag_compute)
   !magnitudes defined in accordance with Fukugita et al. 1996, Eqn 7
   !This routine also redshifts the spectrum, if necessary.
 
-  USE sps_vars; USE sps_utils, ONLY : linterp, tsum
+  USE sps_vars
+  USE sps_utils, ONLY : linterp, tsum
   IMPLICIT NONE
 
   INTEGER  :: i

--- a/src/getspec.f90
+++ b/src/getspec.f90
@@ -7,7 +7,8 @@ SUBROUTINE GETSPEC(pset,mact,logt,lbol,logg,phase,ffco,lmdot,wght,spec)
   ! This subroutine is a major bottleneck.  The spectra must be
   ! recomputed each time the IMF or isochrone parameters change.
 
-  USE sps_vars; USE sps_utils, ONLY: locate
+  USE sps_vars
+  USE sps_utils, ONLY: locate
   IMPLICIT NONE
 
   REAL(SP), INTENT(in) :: mact,logt,lbol,logg,phase,ffco,wght,lmdot

--- a/src/igm_absorb.f90
+++ b/src/igm_absorb.f90
@@ -4,7 +4,8 @@ FUNCTION IGM_ABSORB(lam,spec,zz,factor)
   !this routine includes a fudge factor (accessed by pset%igm_factor)
   !that allows the user to scale the IGM optical depth
 
-  USE sps_vars; USE sps_utils, ONLY : locate
+  USE sps_vars
+  USE sps_utils, ONLY : locate
   IMPLICIT NONE
 
   REAL(SP), DIMENSION(nspec), INTENT(in) :: lam,spec

--- a/src/imf_weight.f90
+++ b/src/imf_weight.f90
@@ -10,7 +10,8 @@ SUBROUTINE IMF_WEIGHT(mini,wght,nmass)
   !mass+/-0.5dm, rather than just the values at point i.
   !Then every intergral over mass is just a sum.
 
-  USE sps_vars; USE sps_utils, ONLY : imf, funcint
+  USE sps_vars
+  USE sps_utils, ONLY : imf, funcint
   IMPLICIT NONE
 
   REAL(SP), INTENT(inout), DIMENSION(nm) :: wght

--- a/src/lesssimple.f90
+++ b/src/lesssimple.f90
@@ -1,7 +1,8 @@
 PROGRAM LESSSIMPLE
 
   !set up modules
-  USE sps_vars; USE sps_utils
+  USE sps_vars
+  USE sps_utils
   
   IMPLICIT NONE
 

--- a/src/linterp.f90
+++ b/src/linterp.f90
@@ -2,7 +2,8 @@ FUNCTION LINTERP(xin,yin,xout)
 
   !routine to linearly interpolate a function yin(xin) at xout
 
-  USE sps_vars; USE sps_utils, ONLY: locate
+  USE sps_vars
+  USE sps_utils, ONLY: locate
   IMPLICIT NONE
   REAL(SP), DIMENSION(:), INTENT(in) :: xin,yin
   REAL(SP), INTENT(in)  :: xout

--- a/src/linterparr.f90
+++ b/src/linterparr.f90
@@ -2,7 +2,8 @@ FUNCTION LINTERPARR(xin,yin,xout)
 
   !routine to linearly interpolate a function yin(xin) at xout
 
-  USE sps_vars; USE sps_utils, ONLY: locate
+  USE sps_vars
+  USE sps_utils, ONLY: locate
   IMPLICIT NONE
   REAL(SP), DIMENSION(:), INTENT(in) :: xin,yin
   REAL(SP), INTENT(in), DIMENSION(:) :: xout

--- a/src/pz_convol.f90
+++ b/src/pz_convol.f90
@@ -7,7 +7,8 @@ SUBROUTINE PZ_CONVOL(yield,zave,spec_pz,lbol_pz,mass_pz)
   !variables spec_ssp_zz, mass_ssp_zz, and lbol_ssp_zz
   !The average metallicity is returned as zave
 
-  USE sps_vars; USE sps_utils, ONLY : linterp
+  USE sps_vars
+  USE sps_utils, ONLY : linterp
   IMPLICIT NONE
   
   INTEGER  :: i,t,z

--- a/src/simple.f90
+++ b/src/simple.f90
@@ -1,7 +1,8 @@
  PROGRAM SIMPLE
 
   !set up modules
-  USE sps_vars; USE sps_utils  
+  USE sps_vars
+  USE sps_utils  
   IMPLICIT NONE
 
   !NB: the various structure types are defined in sps_vars.f90

--- a/src/smoothspec.f90
+++ b/src/smoothspec.f90
@@ -7,7 +7,8 @@ SUBROUTINE SMOOTHSPEC(lambda,spec,sigma,minl,maxl,ires)
   !If optional input ires is present, then the spectrum will be
   !smoothed by a wavelength dependent velocity dispersion.
 
-  USE sps_vars; USE sps_utils, ONLY : locate,linterp,tsum,linterparr
+  USE sps_vars
+  USE sps_utils, ONLY : locate,linterp,tsum,linterparr
   IMPLICIT NONE
   
   REAL(SP), INTENT(inout), DIMENSION(nspec) :: spec

--- a/src/sps_setup.f90
+++ b/src/sps_setup.f90
@@ -9,7 +9,8 @@ SUBROUTINE SPS_SETUP(zin)
   !is read.  Specifying only the metallicity of interest results
   !in a much faster setup.
 
-  USE sps_vars; USE sps_utils
+  USE sps_vars
+  USE sps_utils
   IMPLICIT NONE
   INTEGER, INTENT(in) :: zin
   INTEGER :: stat=1,n,i,j,m,jj,k,i1,i2

--- a/src/ssp_gen.f90
+++ b/src/ssp_gen.f90
@@ -16,7 +16,8 @@
 
 SUBROUTINE SSP_GEN(pset,mass_ssp,lbol_ssp,spec_ssp)
 
-  USE sps_vars; USE sps_utils
+  USE sps_vars
+  USE sps_utils
   IMPLICIT NONE
   
   INTEGER :: i=1, j=1, stat,ii,klo,khi,tlo,thi

--- a/src/vacairconv.f90
+++ b/src/vacairconv.f90
@@ -4,7 +4,8 @@ FUNCTION AIRTOVAC(lam)
   !see Morton (1991 Ap.J. Suppl. 77, 119)
   !this code was adapted from the IDL routine airtovac.pro
 
-  USE sps_vars; USE sps_utils, ONLY : locate
+  USE sps_vars
+  USE sps_utils, ONLY : locate
   IMPLICIT NONE
 
   INTEGER :: vv,nn
@@ -43,7 +44,8 @@ FUNCTION VACTOAIR(lam)
   !see Morton (1991 Ap.J. Suppl. 77, 119)
   !this code was adapted from the IDL routine vactoair.pro
 
-  USE sps_vars; USE sps_utils, ONLY : locate
+  USE sps_vars
+  USE sps_utils, ONLY : locate
   IMPLICIT NONE
 
   INTEGER :: vv,nn

--- a/src/ztinterp.f90
+++ b/src/ztinterp.f90
@@ -5,7 +5,8 @@ SUBROUTINE ZTINTERP(zpos,spec,lbol,mass,tpos,zpow)
   !2) integrate over an MDF (zpos,zpow) for a grid of ages
   !3) single metallicity (zpos) for a grid of ages
 
-  USE sps_vars; USE sps_utils, ONLY : locate, tsum
+  USE sps_vars
+  USE sps_utils, ONLY : locate, tsum
   IMPLICIT NONE
 
   REAL(SP),INTENT(in) :: zpos


### PR DESCRIPTION
In working on https://github.com/dfm/python-fsps/issues/186, I discovered that the meson build system that we're trying to use for the Python bindings doesn't support multiple module includes per line. That's really a bug in meson, but the easiest fix is probably to just split the `use` commands here. I don't think this should introduce any issues - any thoughts?