### PR TITLE
sps_setup.f90: Fix path for loading basel.res

### DIFF
--- a/src/sps_setup.f90
+++ b/src/sps_setup.f90
@@ -223,7 +223,7 @@ SUBROUTINE SPS_SETUP(zin)
           STATUS='OLD',iostat=stat,ACTION='READ')
      OPEN(93,FILE=TRIM(SPS_HOME)//'/SPECTRA/BaSeL3.1/zlegend.dat',&
           STATUS='OLD',iostat=stat,ACTION='READ')
-     OPEN(94,FILE=TRIM(SPS_HOME)//'SPECTRA/BaSeL3.1/basel.res',&
+     OPEN(94,FILE=TRIM(SPS_HOME)//'/SPECTRA/BaSeL3.1/basel.res',&
           STATUS='OLD',iostat=stat,ACTION='READ')
   ELSE IF (spec_type.EQ.'miles') THEN
      OPEN(91,FILE=TRIM(SPS_HOME)//'/SPECTRA/MILES/miles.lambda',&


### PR DESCRIPTION
There is a missing forward slash in the import path that prevents `basel.res` from being loaded correctly.