### PR TITLE
Fix add remnants for low IMF upper mass limit.

### DIFF
--- a/src/add_remnants.f90
+++ b/src/add_remnants.f90
@@ -23,7 +23,8 @@ SUBROUTINE ADD_REMNANTS(mass,maxmass)
 
   !BH remnants
   !40<M<imf_up leave behind a 0.5*M BH
-  minmass = MAXVAL((/mlim_bh,maxmass/))
+  !if imf_upper_limit < 40, add no mass
+  minmass = MIN(MAXVAL((/mlim_bh,maxmass/)), imf_upper_limit)
   imf_type = imf_type+10
   mass = mass + 0.5*funcint(imf,minmass,imf_upper_limit)/imfnorm
   imf_type = imf_type-10
@@ -32,15 +33,15 @@ SUBROUTINE ADD_REMNANTS(mass,maxmass)
   !8.5<M<40 leave behind 1.4 Msun NS
   IF (maxmass.LE.mlim_bh) THEN
      minmass = MAXVAL((/mlim_ns,maxmass/))
-     mass = mass + 1.4*funcint(imf,minmass,mlim_bh)/imfnorm
+     mass = mass + 1.4*funcint(imf,minmass,MIN(mlim_bh, imf_upper_limit))/imfnorm
   ENDIF
 
   !WD remnants
   !M<8.5 leave behind 0.077*M+0.48 WD
   IF (maxmass.LE.8.5) THEN
-     mass = mass + 0.48*funcint(imf,maxmass,mlim_ns)/imfnorm
+     mass = mass + 0.48*funcint(imf,maxmass,MIN(mlim_ns, imf_upper_limit))/imfnorm
      imf_type = imf_type+10
-     mass = mass + 0.077*funcint(imf,maxmass,mlim_ns)/imfnorm
+     mass = mass + 0.077*funcint(imf,maxmass,MIN(mlim_ns, imf_upper_limit))/imfnorm
      imf_type = imf_type-10
 
   ENDIF

--- a/src/add_remnants.f90
+++ b/src/add_remnants.f90
@@ -1,9 +1,9 @@
 SUBROUTINE ADD_REMNANTS(mass,maxmass)
 
   !add remnant (WD, NS, BH) masses back into the total mass
-  !of the SSP.  These initial-mass-dependent remnant 
+  !of the SSP.  These initial-mass-dependent remnant
   !formulae are taken from Renzini & Ciotti 1993.
-  
+
   USE sps_vars
   USE sps_utils, ONLY : imf, funcint
   IMPLICIT NONE
@@ -21,27 +21,30 @@ SUBROUTINE ADD_REMNANTS(mass,maxmass)
   imfnorm  = funcint(imf,imf_lower_limit,imf_upper_limit)
   imf_type = imf_type-10
 
-  !BH remnants
-  !40<M<imf_up leave behind a 0.5*M BH
-  !if imf_upper_limit < 40, add no mass
+  !BH remnants if any
+  !40<M_max<imf_up leave behind a 0.5*M BH
+  !if imf_upper_limit < 40 or < maxmass, add no mass since no stars could make BH and mlo=mhi=imf_upper_limit
   minmass = MIN(MAXVAL((/mlim_bh,maxmass/)), imf_upper_limit)
   imf_type = imf_type+10
   mass = mass + 0.5*funcint(imf,minmass,imf_upper_limit)/imfnorm
   imf_type = imf_type-10
 
-  !NS remnants
-  !8.5<M<40 leave behind 1.4 Msun NS
+  !Add NS remnants
+  !8.5<M_max<40 also eave behind 1.4 Msun NS
+  !if imf_upper_limit < 8.5 , add no mass since no stars could make NS, and mlo=mhi=imf_upper_limit
   IF (maxmass.LE.mlim_bh) THEN
-     minmass = MAXVAL((/mlim_ns,maxmass/))
+     minmass = MIN(MAXVAL((/mlim_ns,maxmass/)), imf_upper_limit)
      mass = mass + 1.4*funcint(imf,minmass,MIN(mlim_bh, imf_upper_limit))/imfnorm
   ENDIF
 
-  !WD remnants
-  !M<8.5 leave behind 0.077*M+0.48 WD
+  !Add WD remnants
+  !M_max<8.5 also leave behind 0.077*M+0.48 WD
+  !if imf_upper_limit < 8.5, only add mass if maxmass < imf_upper_limit since otherwise no stars have evolved and mlo=mhi=imf_upper_limit
   IF (maxmass.LE.8.5) THEN
-     mass = mass + 0.48*funcint(imf,maxmass,MIN(mlim_ns, imf_upper_limit))/imfnorm
+     minmass = MIN(maxmass, imf_upper_limit)
+     mass = mass + 0.48*funcint(imf,minmass,MIN(mlim_ns, imf_upper_limit))/imfnorm
      imf_type = imf_type+10
-     mass = mass + 0.077*funcint(imf,maxmass,MIN(mlim_ns, imf_upper_limit))/imfnorm
+     mass = mass + 0.077*funcint(imf,minmass,MIN(mlim_ns, imf_upper_limit))/imfnorm
      imf_type = imf_type-10
 
   ENDIF


### PR DESCRIPTION
This fixes an issue with integrating the remnant mass function when the IMF upper limit was low. @cconroy20 can you check the logic?  I ran a few tests, attached, with log(Age) = 7.5 and 5.5 yrs, solarish metallicity

![imf_remnants_loga=7 5](https://github.com/cconroy20/fsps/assets/4146628/ae25ebd2-fa2d-4c76-9696-1bb19ab1475c)
![imf_remnants_loga=5 5](https://github.com/cconroy20/fsps/assets/4146628/49bf5da8-3e90-47c9-8920-6ed4e16c04a8)

